### PR TITLE
proposed unified code formatting 

### DIFF
--- a/command.c
+++ b/command.c
@@ -2,10 +2,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-<<<<<<< Updated upstream
-=======
-#include <string.h>
->>>>>>> Stashed changes
 #include <sys/wait.h>
 #include <unistd.h>
 #include "const.h"
@@ -16,7 +12,6 @@ void executeCommand(char* input) {
   char* args[MAX_ARGS + 1] = {NULL};
   input[strlen(input) - 1] = '\0';  // terminate with null, rather than with \n
 
-<<<<<<< Updated upstream
   char* args[MAX_ARGS + 1] = { NULL };
   input[strlen(input) - 1] = '\0'; //terminate with null, rather than with \n
 
@@ -27,14 +22,6 @@ void executeCommand(char* input) {
       token = strtok(NULL, " ");
   }
   if(args[0] == NULL) return;
-=======
-  char* token = strtok(input, " ");
-  for (int i = 0; token != NULL && i < MAX_ARGS; ++i) {
-    args[i] = token;
-    token = strtok(NULL, " ");
-  }
-  if (args[0] == NULL) return;  // empty input
->>>>>>> Stashed changes
 
   // if command includes "=" set variable with the value after "=" as sting
   if (strchr(args[0], '=') != NULL) {
@@ -55,21 +42,10 @@ void executeCommand(char* input) {
     {
       int comm_res = execvp(args[0], args);
 
-<<<<<<< Updated upstream
      if (fork() == 0) // if inside the child process
      {
          exit(execvp(args[0], args));
      }
-=======
-      if (comm_res == -1)  // execvp encountered error
-      {
-        printf("Command '%s' exited with the following error: %s \n", args[0],
-               strerror(errno));
-        exit(-1);
-      } else
-        exit(0);
-    }
->>>>>>> Stashed changes
   }
   wait(NULL);
 }


### PR DESCRIPTION
Hey All,

I don't wanna play any formatting sheriff here, but we are running into some issues (see f7f391e4c961186760dd4cec2e386ed2eabfc04c ).

We have 2 space vs 4 space indent mixed, and later they can occur as changes if we edit file using a different editor. How about we stick to one format?  

We could, for example use a formatting tool to adhere to one format (google style guide in this case):
```
clang-format -style=google command.c > command_formatted.c
```

This PR is just to show how it would work on one file. Let me know what you think!