### PR TITLE
Added [roshell] tag to tell that we're inside roshell

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[], char* envp[]) {
     while (1)
     {
         char input[MAX_COMM_SIZE + 1] = { 0x0 };
-        printf("%s@%s $:", username,hostname);
+        printf("[roshell] %s@%s:$ ", username, hostname);
         fgets(input, MAX_COMM_SIZE, stdin);
 
         executeCommand(input);


### PR DESCRIPTION
A simple one line fix to tell if we're inside `roshell` or not. Also, fixed the position of `$` sign after the `:`