### PR TITLE
Eigen Vector support in RoshellGraphics + Housekeeping

### DIFF
--- a/ros_ws/src/roshell_graphics/include/roshell_graphics/roshell_graphics.h
+++ b/ros_ws/src/roshell_graphics/include/roshell_graphics/roshell_graphics.h
@@ -68,7 +68,7 @@ public:
     std::pair<int, int> get_terminal_size();
 
     // Geometry functions
-    std::vector<int> line(const Point& pp1, const Point& pp2, char c = ' ');
+    void line(const Point& pp1, const Point& pp2, char c = ' ');
     void add_frame();
 
     // Text functions
@@ -77,6 +77,8 @@ public:
     // Public Utility functions
     void fix_frame(Point& p);
     void fill_buffer(const int& idx, char c = ' ');
+    // Overloaded function that takes point in screen frame
+    void fill_buffer(const Point& p, char c = ' ');
 
     // Drawing functions
     void draw();
@@ -164,6 +166,9 @@ void RoshellGraphics::clear_buffer()
     buffer_count_ = std::vector<int>(buffer_len, 0);
 }
 
+/**
+ * Fill buffer given encoded index and a character (optional)
+*/
 void RoshellGraphics::fill_buffer(const int& idx, char c)
 {
     if (c != ' ')
@@ -177,12 +182,23 @@ void RoshellGraphics::fill_buffer(const int& idx, char c)
 }
 
 /**
+ * Overloaded method that takes in a Point in screen coordinates to fill the buffer
+ * if in bounds.
+*/
+void RoshellGraphics::fill_buffer(const Point& p, char c)
+{
+    if (is_within_limits_(p))
+    {
+        int idx = encode_point_(p);
+        fill_buffer(idx, c);
+    }
+}
+
+/**
  * Draws a line between two points provided in the Natural Reference frame
 */
-std::vector<int> RoshellGraphics::line(const Point& pp1, const Point& pp2, char c)
+void RoshellGraphics::line(const Point& pp1, const Point& pp2, char c)
 {   
-    std::vector<int> indices;
-    
     // Make copies so they can be modified
     Point p1 = pp1;
     Point p2 = pp2;
@@ -199,18 +215,16 @@ std::vector<int> RoshellGraphics::line(const Point& pp1, const Point& pp2, char 
         {
             for (int y = p1(1); y < p2(1); y++)
             {
-                int idx = encode_point_({p1(0), y});
-                indices.push_back(idx);
-                fill_buffer(idx, c);
+                Point p = {p1(0), y};
+                fill_buffer(p, c);
             }
         }
         else
         {
             for (int y = p2(1); y < p1(1); y++)
             {
-                int idx = encode_point_({p1(0), y});
-                indices.push_back(idx);
-                fill_buffer(idx, c);
+                Point p = {p1(0), y};
+                fill_buffer(p, c);
             }
         }
     }
@@ -225,18 +239,16 @@ std::vector<int> RoshellGraphics::line(const Point& pp1, const Point& pp2, char 
             {
                 for (int x = p1(0); x < p2(0); x++)
                 {
-                    int idx = encode_point_({x, p1(1) + slope * (x - p1(0))});
-                    indices.push_back(idx);
-                    fill_buffer(idx, c);
+                    Point p = {x, p1(1) + slope * (x - p1(0))};
+                    fill_buffer(p, c);
                 }
             }
             else
             {
                 for (int x = p2(0); x < p1(0); x++)
                 {
-                    int idx = encode_point_({x, p1(1) + slope * (x - p1(0))});
-                    indices.push_back(idx);
-                    fill_buffer(idx, c);
+                    Point p = {x, p1(1) + slope * (x - p1(0))};
+                    fill_buffer(p, c);
                 }
             }
         }
@@ -246,23 +258,20 @@ std::vector<int> RoshellGraphics::line(const Point& pp1, const Point& pp2, char 
             {
                 for (int y = p1(1); y < p2(1); y++)
                 {
-                    int idx = encode_point_({p1(0) + (y - p1(1)) / slope, y});
-                    indices.push_back(idx);
-                    fill_buffer(idx, c);
+                    Point p = {p1(0) + (y - p1(1)) / slope, y};
+                    fill_buffer(p, c);
                 }
             }
             else
             {
                 for (int y = p2(1); y < p1(1); y++)
                 {
-                    int idx = encode_point_({p1(0) + (y - p1(1)) / slope, y});
-                    indices.push_back(idx);
-                    fill_buffer(idx, c);
+                    Point p = {p1(0) + (y - p1(1)) / slope, y};
+                    fill_buffer(p, c);
                 }
             }
         }
     }
-    return indices;
 }
 
 /**

--- a/ros_ws/src/roshell_graphics/src/roshell_graphics_test_node.cpp
+++ b/ros_ws/src/roshell_graphics/src/roshell_graphics_test_node.cpp
@@ -197,8 +197,8 @@ int main(int argc, char** argv)
     // draw_lines(rg);
     // draw_3D_axis(rg, pp);
 
-    // draw_rotating_cube(rg, '/');
-    test_add_text(rg, "Yay! this actually works now let's stress it! It needs to be longer than this");
+    draw_rotating_cube(rg, '/');
+    // test_add_text(rg, "Yay! this actually works now let's stress it! It needs to be longer than this");
 
     return 0;
 }


### PR DESCRIPTION
This PR contains a bunch of improvements and housekeeping changes to `RoshellGraphics` library that will be super helpful in the future. Some of the changes:

1. Added Eigen Support. This means we don't need to convert Points to `std::pair<int, int>` before drawing them! This will also help in projecting multiple points at once (more benefits coming in future PR).
2. Added `fill_buff()` function and density support. This will automatically fill a pixel with a "denser" point depending on how many 3D points map to that pixel. 
3. Added the concept of `Natural Frame` (with origin in the middle of the screen), and `Screen Frame` with the center in the top-left corner of the screen.
4. No need to call `fix_frame()` function. Now, all `RoshellGraphics` functions will be responsible for converting from `Natural Frame` to `Screen Frame`. All drawing related public functions will only take in points to draw on in the `Natural Frame`.
5. Added more helpful comments (more incoming)
6. The test node is updated with fixed code examples as well.
7. Added support for adding text to the screen.

This version of `RoshellGraphics` will enable line plotting completely. 